### PR TITLE
Fixes issue where needed slashes were stripped.

### DIFF
--- a/includes/API/ForkPostController.php
+++ b/includes/API/ForkPostController.php
@@ -60,7 +60,8 @@ class ForkPostController {
 			);
 		}
 
-		add_filter( 'wp_insert_post_data', 'wp_slash' );
+		// Adds slashes as data passed by API strips slashes.
+		add_filter( 'safe_edit_prepared_post_data_for_fork', 'wp_slash' );
 
 		$forker = new PostForker();
 		$fork_post_id = $forker->fork( $post_id );

--- a/includes/API/MergePostController.php
+++ b/includes/API/MergePostController.php
@@ -53,7 +53,8 @@ class MergePostController {
 			);
 		}
 
-		add_filter( 'wp_insert_post_data', 'wp_slash' );
+		// Adds slashes as data passed by API strips slashes.
+		add_filter( 'safe_edit_prepared_post_data_for_merge', 'wp_slash' );
 
 		try {
 			$_POST            = (array) get_post( $post_id );

--- a/includes/Forking/PostMerger.php
+++ b/includes/Forking/PostMerger.php
@@ -155,7 +155,8 @@ class PostMerger extends AbstractMerger  {
 				);
 			}
 
-			return $post_data;
+			// Converts to an object for escaping.
+			return apply_filters( 'safe_edit_prepared_post_data_for_merge', $post_data );
 
 		} catch ( Exception $e ) {
 			\TenUp\WPSafeEdit\Logging\log_exception( $e );

--- a/includes/functions/post-helpers.php
+++ b/includes/functions/post-helpers.php
@@ -292,7 +292,7 @@ function current_user_can_fork_post( $post ) {
 	}
 
 	$post_type = get_post_type_object( $post->post_type );
-	
+
 	// First determine if the user can edit published posts.
 	$edit_published_privilege = $post_type->cap->edit_published_posts;
 	$value                    = current_user_can( $edit_published_privilege );
@@ -331,7 +331,7 @@ function current_user_can_merge_post( $post ) {
 	}
 
 	$post_type = get_post_type_object( $post->post_type );
-	
+
 	// First determine if the user can publish posts.
 	$published_privilege = $post_type->cap->publish_posts;
 	$value               = current_user_can( $published_privilege );


### PR DESCRIPTION
Fixes #10.

This fixes an issue where Gutenberg JSON data was getting
corrupted by `wp_unslash`, called in `wp_insert_post`.

Note this has only been tested with Gutenberg, not the classic editor.