### PR TITLE
Use esc_url_raw and wp_safe_redirect for internal redirects

### DIFF
--- a/includes/API/ForkPostController.php
+++ b/includes/API/ForkPostController.php
@@ -155,7 +155,7 @@ class ForkPostController {
 			), $url );
 		}
 
-		wp_redirect( esc_url( $url ) );
+		wp_safe_redirect( esc_url_raw( $url ) );
 		exit;
 	}
 
@@ -181,7 +181,7 @@ class ForkPostController {
 
 		$url = apply_filters( 'safe_edit_post_fork_failure_redirect_url', $url, $source_post_id, $result );
 
-		wp_redirect( esc_url( $url ) );
+		wp_safe_redirect( esc_url_raw( $url ) );
 		exit;
 	}
 

--- a/includes/API/MergePostController.php
+++ b/includes/API/MergePostController.php
@@ -170,7 +170,7 @@ class MergePostController {
 			), $url );
 		}
 
-		wp_redirect( esc_url( $url ) );
+		wp_safe_redirect( esc_url_raw( $url ) );
 		exit;
 	}
 
@@ -196,7 +196,7 @@ class MergePostController {
 
 		$url = apply_filters( 'safe_edit_post_merge_failure_redirect_url', $url, $fork_post_id, $result );
 
-		wp_redirect( esc_url( $url ) );
+		wp_safe_redirect( esc_url_raw( $url ) );
 		exit;
 	}
 


### PR DESCRIPTION
This fixes an issue I was experiencing where the redirects defined in the controllers were attempting to redirect to encoded urls.  [`esc_url_raw`](https://developer.wordpress.org/reference/functions/esc_url_raw/) should be [used to pass safe urls into `wp_redirect` and `wp_safe_redirect`.](https://konstantin.blog/2012/esc_url-vs-esc_url_raw/)